### PR TITLE
[codex] polish shell basics archive readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,34 +2,43 @@
 
 # Linux Networking Shell Basics
 
-UNIX/Linux command collection for networking lookups, system inspection, and a few Bash utilities.
+UNIX/Linux command collection for networking lookups, system inspection, and Bash utility scripts.
 
-[![Shell checks](https://img.shields.io/github/actions/workflow/status/itkrivoshei/linux-networking-shell-basics/shell.yml?branch=main&style=for-the-badge&label=shell%20checks&logo=githubactions&logoColor=white)](https://github.com/itkrivoshei/linux-networking-shell-basics/actions/workflows/shell.yml)
-[![Bash](https://img.shields.io/badge/Bash-scripts-4eaa25?style=for-the-badge&logo=gnubash&logoColor=white)](scripting)
-[![License](https://img.shields.io/github/license/itkrivoshei/linux-networking-shell-basics?style=for-the-badge)](LICENSE)
+[![Shell checks](https://img.shields.io/github/actions/workflow/status/itkrivoshei/linux-networking-shell-basics/shell.yml?branch=main&style=for-the-badge&label=shell%20checks&logo=githubactions&logoColor=white&labelColor=0f172a)](https://github.com/itkrivoshei/linux-networking-shell-basics/actions/workflows/shell.yml)
+[![Bash](https://img.shields.io/badge/Bash-scripts-4eaa25?style=for-the-badge&logo=gnubash&logoColor=white&labelColor=0f172a)](scripting)
+[![License](https://img.shields.io/github/license/itkrivoshei/linux-networking-shell-basics?style=for-the-badge&labelColor=0f172a)](LICENSE)
 
 </div>
 
+## Overview
+
+This repository contains small UNIX/Linux command references and Bash scripts for:
+
+- networking lookups and diagnostics;
+- system inspection;
+- basic shell scripting practice;
+- running commands through a simple interactive menu.
+
+Some commands reflect BSD/macOS-style output, such as `ifconfig en0` or `netstat -nr`, and may need adjustment on a modern Linux host.
+
 ## Repository Areas
 
-| Directory | Contents |
-| --- | --- |
-| `network/` | Commands around interfaces, routing, DNS, ARP, traceroute, and services |
-| `system/` | System information, users, processes, packages, paths, and permissions |
-| `scripting/` | Bash scripts plus an interactive menu for browsing/running items |
+| Directory                 | Contents                                                                |
+| ------------------------- | ----------------------------------------------------------------------- |
+| [`network/`](network)     | Commands around interfaces, routing, DNS, ARP, traceroute, and services |
+| [`system/`](system)       | System information, users, processes, packages, paths, and permissions  |
+| [`scripting/`](scripting) | Bash scripts plus an interactive menu for browsing and running items    |
 
-Some commands reflect BSD/macOS style output (`ifconfig en0`, `netstat -nr`) and may need adjustment on a modern Linux host.
+## Usage
 
-## Run
-
-Inspect a command file:
+Inspect command examples:
 
 ```bash
 cat network/04
 cat system/01
 ```
 
-Run the menu:
+Run the interactive menu:
 
 ```bash
 cd scripting
@@ -43,22 +52,28 @@ cd scripting
 ./01
 ```
 
-`scripting/02` can delete local users. It is blocked by default and requires an explicit opt-in:
+## Safety Note
+
+[`scripting/02`](scripting/02) can delete local users.
+
+It is blocked by default and requires an explicit opt-in:
 
 ```bash
 cd scripting
 ALLOW_USER_DELETE=1 ./02
 ```
 
-Review it before running on any real machine.
+Review the script before running it on any real machine.
 
-## Check Syntax
+## Checks
+
+Run Bash syntax validation locally:
 
 ```bash
 bash -n network/* system/* scripting/*
 ```
 
-The GitHub Actions workflow runs Bash syntax validation for all files under `network/`, `system/`, and `scripting/`.
+The [GitHub Actions workflow](.github/workflows/shell.yml) runs Bash syntax validation for files under [`network/`](network), [`system/`](system), and [`scripting/`](scripting).
 
 ## License
 

--- a/scripting/02
+++ b/scripting/02
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "WARNING: this archived exercise can delete local users."
+echo "WARNING: this exercise can delete local users."
 echo "Set ALLOW_USER_DELETE=1 to continue."
 if [ "${ALLOW_USER_DELETE:-}" != "1" ]; then
 	echo "Blocked by safety guard."


### PR DESCRIPTION
## Summary
- Polish README guidance for shell basics archive readiness.
- Clarify the user-deletion safety guard wording in `scripting/02`.

## Validation
- `bash -lc 'set -euo pipefail; mapfile -d "" files < <(find network system scripting -type f ! -name ".*" -print0); bash -n "${files[@]}"'`

## Archive-readiness
- Default branch: `main`
- Remote branch cleanup target after merge: keep only `main`